### PR TITLE
Add DeepSeek and Gemini defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,11 @@ You will need the OpenAI API for all the agents.
 ```bash
 export OPENAI_API_KEY=$YOUR_OPENAI_API_KEY
 ```
+If you want to try DeepSeek or Gemini models, set their API keys as well.
+```bash
+export DEEPSEEK_API_KEY=$YOUR_DEEPSEEK_API_KEY
+export GOOGLE_API_KEY=$YOUR_GOOGLE_API_KEY
+```
 
 ### CLI Usage
 
@@ -150,7 +155,9 @@ An interface will appear showing results as they load, letting you track the age
 
 ### Implementation Details
 
-We built TradingAgents with LangGraph to ensure flexibility and modularity. We utilize `o1-preview` and `gpt-4o` as our deep thinking and fast thinking LLMs for our experiments. However, for testing purposes, we recommend you use `o4-mini` and `gpt-4.1-mini` to save on costs as our framework makes **lots of** API calls.
+We built TradingAgents with LangGraph to ensure flexibility and modularity. By default, `deepseek-chat` handles deep thinking while `gemini-1.5-flash-latest` is used for quick thinking. These defaults can be customized, and you may still opt for `o4-mini` and `gpt-4.1-mini` for cost‑sensitive experiments.
+
+If you have access to the preview model `gemini-flash-2.5-preview`, you can select it when running the CLI. The code will automatically fall back to `gemini-1.5-flash-latest` if the preview model is unavailable.
 
 ### Python Usage
 
@@ -175,8 +182,8 @@ from tradingagents.default_config import DEFAULT_CONFIG
 
 # Create a custom config
 config = DEFAULT_CONFIG.copy()
-config["deep_think_llm"] = "gpt-4.1-nano"  # Use a different model
-config["quick_think_llm"] = "gpt-4.1-nano"  # Use a different model
+config["deep_think_llm"] = "o4-mini"  # Use a different model
+config["quick_think_llm"] = "gpt-4.1-mini"  # Use a different model
 config["max_debate_rounds"] = 1  # Increase debate rounds
 config["online_tools"] = True # Use online tools or cached data
 

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -131,6 +131,10 @@ def select_shallow_thinking_agent() -> str:
         ("GPT-4.1-nano - Ultra-lightweight model for basic operations", "gpt-4.1-nano"),
         ("GPT-4.1-mini - Compact model with good performance", "gpt-4.1-mini"),
         ("GPT-4o - Standard model with solid capabilities", "gpt-4o"),
+        ("Gemini Flash 1.5 (latest)", "gemini-1.5-flash-latest"),
+        ("Gemini Flash 2.5 (preview)", "gemini-flash-2.5-preview"),
+        ("Gemini Pro - Google Generative AI", "gemini-pro"),
+        ("DeepSeek Chat", "deepseek-chat"),
     ]
 
     choice = questionary.select(
@@ -170,6 +174,9 @@ def select_deep_thinking_agent() -> str:
         ("o3-mini - Advanced reasoning model (lightweight)", "o3-mini"),
         ("o3 - Full advanced reasoning model", "o3"),
         ("o1 - Premier reasoning and problem-solving model", "o1"),
+        ("Gemini Pro - Google Generative AI", "gemini-pro"),
+        ("Gemini 1.5 Pro", "gemini-1.5-pro-latest"),
+        ("DeepSeek Chat", "deepseek-chat"),
     ]
 
     choice = questionary.select(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 typing-extensions
 langchain-openai
+langchain-google-genai
+langchain-deepseek
+deepseek
 langchain-experimental
 pandas
 yfinance

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,9 @@ setup(
     install_requires=[
         "langchain>=0.1.0",
         "langchain-openai>=0.0.2",
+        "langchain-google-genai",
+        "langchain-deepseek",
+        "deepseek",
         "langchain-experimental>=0.0.40",
         "langgraph>=0.0.20",
         "numpy>=1.24.0",

--- a/tradingagents/agents/analysts/fundamentals_analyst.py
+++ b/tradingagents/agents/analysts/fundamentals_analyst.py
@@ -52,7 +52,7 @@ def create_fundamentals_analyst(llm, toolkit):
         result = chain.invoke(state["messages"])
 
         return {
-            "messages": [result],
+            "messages": state["messages"] + [result],
             "fundamentals_report": result.content,
         }
 

--- a/tradingagents/agents/analysts/market_analyst.py
+++ b/tradingagents/agents/analysts/market_analyst.py
@@ -77,7 +77,7 @@ Volume-Based Indicators:
         result = chain.invoke(state["messages"])
 
         return {
-            "messages": [result],
+            "messages": state["messages"] + [result],
             "market_report": result.content,
         }
 

--- a/tradingagents/agents/analysts/news_analyst.py
+++ b/tradingagents/agents/analysts/news_analyst.py
@@ -48,7 +48,7 @@ def create_news_analyst(llm, toolkit):
         result = chain.invoke(state["messages"])
 
         return {
-            "messages": [result],
+            "messages": state["messages"] + [result],
             "news_report": result.content,
         }
 

--- a/tradingagents/agents/analysts/social_media_analyst.py
+++ b/tradingagents/agents/analysts/social_media_analyst.py
@@ -48,7 +48,7 @@ def create_social_media_analyst(llm, toolkit):
         result = chain.invoke(state["messages"])
 
         return {
-            "messages": [result],
+            "messages": state["messages"] + [result],
             "sentiment_report": result.content,
         }
 

--- a/tradingagents/agents/trader/trader.py
+++ b/tradingagents/agents/trader/trader.py
@@ -35,7 +35,7 @@ def create_trader(llm, memory):
         result = llm.invoke(messages)
 
         return {
-            "messages": [result],
+            "messages": state["messages"] + [result],
             "trader_investment_plan": result.content,
             "sender": name,
         }

--- a/tradingagents/agents/utils/agent_states.py
+++ b/tradingagents/agents/utils/agent_states.py
@@ -1,7 +1,6 @@
 from typing import Annotated, Sequence
 from datetime import date, timedelta, datetime
 from typing_extensions import TypedDict, Optional
-from langchain_openai import ChatOpenAI
 from tradingagents.agents import *
 from langgraph.prebuilt import ToolNode
 from langgraph.graph import END, StateGraph, START, MessagesState

--- a/tradingagents/agents/utils/agent_utils.py
+++ b/tradingagents/agents/utils/agent_utils.py
@@ -9,7 +9,6 @@ import functools
 import pandas as pd
 import os
 from dateutil.relativedelta import relativedelta
-from langchain_openai import ChatOpenAI
 import tradingagents.dataflows.interface as interface
 from tradingagents.default_config import DEFAULT_CONFIG
 

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -8,8 +8,10 @@ DEFAULT_CONFIG = {
         "dataflows/data_cache",
     ),
     # LLM settings
-    "deep_think_llm": "o4-mini",
-    "quick_think_llm": "gpt-4o-mini",
+    "deep_think_llm": "deepseek-chat",
+    # Gemini Flash 1.5 is broadly available. Use this by default to avoid
+    # 404 errors that may occur with preview models.
+    "quick_think_llm": "gemini-1.5-flash-latest",
     # Debate and discussion settings
     "max_debate_rounds": 1,
     "max_risk_discuss_rounds": 1,

--- a/tradingagents/graph/reflection.py
+++ b/tradingagents/graph/reflection.py
@@ -1,13 +1,13 @@
 # TradingAgents/graph/reflection.py
 
 from typing import Dict, Any
-from langchain_openai import ChatOpenAI
+from langchain_core.language_models.chat_models import BaseChatModel
 
 
 class Reflector:
     """Handles reflection on decisions and updating memory."""
 
-    def __init__(self, quick_thinking_llm: ChatOpenAI):
+    def __init__(self, quick_thinking_llm: BaseChatModel):
         """Initialize the reflector with an LLM."""
         self.quick_thinking_llm = quick_thinking_llm
         self.reflection_system_prompt = self._get_reflection_prompt()

--- a/tradingagents/graph/setup.py
+++ b/tradingagents/graph/setup.py
@@ -1,7 +1,7 @@
 # TradingAgents/graph/setup.py
 
 from typing import Dict, Any
-from langchain_openai import ChatOpenAI
+from langchain_core.language_models.chat_models import BaseChatModel
 from langgraph.graph import END, StateGraph, START
 from langgraph.prebuilt import ToolNode
 
@@ -17,8 +17,8 @@ class GraphSetup:
 
     def __init__(
         self,
-        quick_thinking_llm: ChatOpenAI,
-        deep_thinking_llm: ChatOpenAI,
+        quick_thinking_llm: BaseChatModel,
+        deep_thinking_llm: BaseChatModel,
         toolkit: Toolkit,
         tool_nodes: Dict[str, ToolNode],
         bull_memory,

--- a/tradingagents/graph/signal_processing.py
+++ b/tradingagents/graph/signal_processing.py
@@ -1,12 +1,12 @@
 # TradingAgents/graph/signal_processing.py
 
-from langchain_openai import ChatOpenAI
+from langchain_core.language_models.chat_models import BaseChatModel
 
 
 class SignalProcessor:
     """Processes trading signals to extract actionable decisions."""
 
-    def __init__(self, quick_thinking_llm: ChatOpenAI):
+    def __init__(self, quick_thinking_llm: BaseChatModel):
         """Initialize with an LLM for processing."""
         self.quick_thinking_llm = quick_thinking_llm
 

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -6,8 +6,8 @@ import json
 from datetime import date
 from typing import Dict, Any, Tuple, List, Optional
 
-from langchain_openai import ChatOpenAI
 from langgraph.prebuilt import ToolNode
+from langchain_core.language_models.chat_models import BaseChatModel
 
 from tradingagents.agents import *
 from tradingagents.default_config import DEFAULT_CONFIG
@@ -24,6 +24,7 @@ from .setup import GraphSetup
 from .propagation import Propagator
 from .reflection import Reflector
 from .signal_processing import SignalProcessor
+from tradingagents.utils.llm_factory import create_chat_llm
 
 
 class TradingAgentsGraph:
@@ -55,9 +56,11 @@ class TradingAgentsGraph:
         )
 
         # Initialize LLMs
-        self.deep_thinking_llm = ChatOpenAI(model=self.config["deep_think_llm"])
-        self.quick_thinking_llm = ChatOpenAI(
-            model=self.config["quick_think_llm"], temperature=0.1
+        self.deep_thinking_llm: BaseChatModel = create_chat_llm(
+            self.config["deep_think_llm"]
+        )
+        self.quick_thinking_llm: BaseChatModel = create_chat_llm(
+            self.config["quick_think_llm"], temperature=0.1
         )
         self.toolkit = Toolkit(config=self.config)
 

--- a/tradingagents/utils/llm_factory.py
+++ b/tradingagents/utils/llm_factory.py
@@ -1,0 +1,48 @@
+import os
+from typing import Any
+
+from langchain_openai import ChatOpenAI
+from langchain_google_genai import ChatGoogleGenerativeAI
+from langchain_deepseek import ChatDeepSeek
+from langchain_core.language_models.chat_models import BaseChatModel
+
+try:
+    from google.api_core.exceptions import NotFound
+except Exception:  # pragma: no cover - package may not be installed during docs build
+    NotFound = Exception
+
+
+DEEPSEEK_BASE_URL = "https://api.deepseek.com/v1"
+
+
+def create_chat_llm(model_name: str, **kwargs: Any) -> BaseChatModel:
+    """Create a chat model instance based on the model name."""
+    temperature = kwargs.pop("temperature", 0.7)
+
+    if model_name.lower().startswith("gemini"):
+        # Google Gemini models
+        try:
+            return ChatGoogleGenerativeAI(
+                model=model_name, temperature=temperature, **kwargs
+            )
+        except NotFound:
+            fallback = "gemini-1.5-flash-latest"
+            if model_name != fallback:
+                print(
+                    f"Model {model_name} not found. Falling back to {fallback}."
+                )
+                return ChatGoogleGenerativeAI(
+                    model=fallback, temperature=temperature, **kwargs
+                )
+            raise
+    if model_name.lower().startswith("deepseek"):
+        # DeepSeek models
+        return ChatDeepSeek(
+            model=model_name,
+            temperature=temperature,
+            api_key=os.getenv("DEEPSEEK_API_KEY"),
+            api_base=DEEPSEEK_BASE_URL,
+            **kwargs,
+        )
+    # Default to OpenAI models
+    return ChatOpenAI(model=model_name, temperature=temperature, **kwargs)


### PR DESCRIPTION
## Summary
- default to `deepseek-chat` for deep thinking and `gemini-1.5-flash-latest` for quick thinking
- allow selecting Gemini Flash 1.5 and 2.5 preview from the CLI
- document updated defaults and mention the preview model option
- support Gemini 1.5 as default in configuration
- automatically fall back to Gemini Flash 1.5 if the preview model isn't available
- preserve message history between analysts so Gemini models receive a user message

## Testing
- `pip install -e .`
- `python - <<'PY'
from tradingagents.graph.trading_graph import TradingAgentsGraph
print('init ok')
PY`


------
https://chatgpt.com/codex/tasks/task_e_684d5181b2d48332a8894a74fab0bb35